### PR TITLE
Fix zypper-broken symlinks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,19 +5,19 @@ go 1.15
 require (
 	github.com/antonfisher/nested-logrus-formatter v1.3.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
-	github.com/davecgh/go-spew v1.1.1
 	github.com/elastic/go-sysinfo v1.7.0
 	github.com/elastic/go-windows v1.0.1 // indirect
 	github.com/infra-whizz/wzlib v0.0.0-20210306212611-2af49aea1704
 	github.com/isbm/go-nanoconf v0.0.0-20200623180822-caf90de1965e
 	github.com/isbm/go-shutil v0.0.0-20200707163617-60e3684d72ba
+	github.com/karrick/godirwalk v1.16.1
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sirupsen/logrus v1.8.1
 	github.com/thoas/go-funk v0.8.0
 	github.com/urfave/cli/v2 v2.3.0
-	golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea
+	golang.org/x/sys v0.0.0-20210601080250-7ecdf8ef093b
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	howett.net/plist v0.0.0-20201203080718-1454fab16a06 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,6 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/elastic/go-sysinfo v1.3.0 h1:eb2XFGTMlSwG/yyU9Y8jVAYLIzU2sFzWXwo2gmetyrE=
 github.com/elastic/go-sysinfo v1.3.0/go.mod h1:i1ZYdU10oLNfRzq4vq62BEwD2fH8KaWh6eh0ikPT9F0=
-github.com/elastic/go-sysinfo v1.6.0 h1:u0QbU8eWSwKRPcFQancnSY4Zi0COksCJXkUgPHxE5Tw=
-github.com/elastic/go-sysinfo v1.6.0/go.mod h1:i1ZYdU10oLNfRzq4vq62BEwD2fH8KaWh6eh0ikPT9F0=
 github.com/elastic/go-sysinfo v1.7.0 h1:4vVvcfi255+8+TyQ7TYUTEK3A+G8v5FLE+ZKYL1z1Dg=
 github.com/elastic/go-sysinfo v1.7.0/go.mod h1:i1ZYdU10oLNfRzq4vq62BEwD2fH8KaWh6eh0ikPT9F0=
 github.com/elastic/go-windows v1.0.0 h1:qLURgZFkkrYyTTkvYpsZIgf83AUsdIHfvlJaqaZ7aSY=
@@ -46,6 +44,8 @@ github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkr
 github.com/jinzhu/now v1.0.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 h1:rp+c0RAYOWj8l6qbCUTSiRLG/iKnW3K3/QfPPuSsBt4=
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901/go.mod h1:Z86h9688Y0wesXCyonoVr47MasHilkuLMqGhRZ4Hpak=
+github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
+github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -116,10 +116,8 @@ golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191025021431-6c3a3bfe00ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210324051608-47abb6519492 h1:Paq34FxTluEPvVyayQqMPgHm+vTOrIifmcYxFBx9TLg=
-golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea h1:+WiDlPBBaO+h9vPNZi8uJ3k4BkKQB7Iow3aqwHVA5hI=
-golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210601080250-7ecdf8ef093b h1:qh4f65QIVFjq9eBURLEYWqaEXmOyqdUyiBSgaXWccWk=
+golang.org/x/sys v0.0.0-20210601080250-7ecdf8ef093b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/pm/fixlets/resymlink.go
+++ b/pm/fixlets/resymlink.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	sysmgr_sr "github.com/infra-whizz/sys-mgr/sr"
@@ -52,7 +53,7 @@ func (rsl *ReSymlink) callback(pathname string, dirEntry *godirwalk.Dirent) erro
 	for _, skipTopDir := range rsl.skipTopDirs {
 		pref := path.Join(rsl.sysroot.Path, skipTopDir)
 		if strings.HasPrefix(pathname, pref) {
-			return nil
+			return filepath.SkipDir
 		}
 	}
 

--- a/pm/fixlets/resymlink.go
+++ b/pm/fixlets/resymlink.go
@@ -1,0 +1,87 @@
+package sysmgr_fixlets
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	sysmgr_sr "github.com/infra-whizz/sys-mgr/sr"
+	"github.com/karrick/godirwalk"
+)
+
+// ReSymlink type
+type ReSymlink struct {
+	skipTopDirs []string
+	sysroot     *sysmgr_sr.SysRoot
+	here        string
+}
+
+// NewReSymlink constructor
+func NewReSymlink(sysroot *sysmgr_sr.SysRoot) *ReSymlink {
+	rsl := new(ReSymlink)
+	rsl.sysroot = sysroot
+	rsl.skipTopDirs = []string{"proc", "sys", "dev", "run", "boot", "tmp", "mnt"}
+
+	var err error
+	rsl.here, err = os.Getwd()
+	if err != nil {
+		panic("Unable to get current directory: " + err.Error())
+	}
+
+	return rsl
+}
+
+// a2r converts an existing pathname link on absolute target to a relative counterpart
+func (rsl *ReSymlink) a2r(pathname string, target string) string {
+	inner := path.Dir(pathname[len(rsl.sysroot.Path):])
+	levels := strings.Split(inner, "/")
+	if levels[0] == "" {
+		levels = levels[1:]
+	}
+	rjump := "./"
+	for i := 0; i < len(levels); i++ {
+		rjump += "../"
+	}
+
+	return path.Clean(path.Join(rjump, target))
+}
+
+// Callback on each dirwalk event
+func (rsl *ReSymlink) callback(pathname string, dirEntry *godirwalk.Dirent) error {
+	for _, skipTopDir := range rsl.skipTopDirs {
+		pref := path.Join(rsl.sysroot.Path, skipTopDir)
+		if strings.HasPrefix(pathname, pref) {
+			return nil
+		}
+	}
+
+	if dirEntry.IsSymlink() {
+		brokenPtr, _ := os.Readlink(pathname)
+		ptrDir := path.Dir(pathname)
+
+		if strings.HasPrefix(brokenPtr, "/") {
+			if err := os.Chdir(ptrDir); err != nil {
+				return fmt.Errorf("Cannot change directory to %s: %s", ptrDir, err.Error())
+			}
+
+			if err := os.Remove(pathname); err != nil {
+				return fmt.Errorf("Broken link (%s) removal error: %s", pathname, err.Error())
+			}
+
+			if err := os.Symlink(rsl.a2r(pathname, brokenPtr), path.Base(pathname)); err != nil {
+				return fmt.Errorf("Symlink error: %s", err.Error())
+			}
+		}
+	}
+
+	return nil
+}
+
+// Relink absolute symlinks to relative
+func (rsl *ReSymlink) Relink() error {
+	opts := &godirwalk.Options{
+		Callback: rsl.callback,
+	}
+	return godirwalk.Walk(rsl.sysroot.Path, opts)
+}

--- a/pm/fixlets/resymlink.go
+++ b/pm/fixlets/resymlink.go
@@ -58,10 +58,13 @@ func (rsl *ReSymlink) callback(pathname string, dirEntry *godirwalk.Dirent) erro
 	}
 
 	if dirEntry.IsSymlink() {
-		brokenPtr, _ := os.Readlink(pathname)
-		ptrDir := path.Dir(pathname)
+		brokenPtr, err := os.Readlink(pathname)
+		if err != nil {
+			return err
+		}
 
 		if strings.HasPrefix(brokenPtr, "/") {
+			ptrDir := path.Dir(pathname)
 			if err := os.Chdir(ptrDir); err != nil {
 				return fmt.Errorf("Cannot change directory to %s: %s", ptrDir, err.Error())
 			}

--- a/pm/zypper.go
+++ b/pm/zypper.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"strings"
 
+	sysmgr_fixlets "github.com/infra-whizz/sys-mgr/pm/fixlets"
 	sysmgr_sr "github.com/infra-whizz/sys-mgr/sr"
 )
 
@@ -33,7 +34,12 @@ func (pm *ZypperPackageManager) Call(args ...string) error {
 	}
 
 	args = append([]string{"--root", pm.sysroot.Path}, args...)
-	return pm.callPackageManager(pm.Name(), args...)
+	if err := pm.callPackageManager(pm.Name(), args...); err != nil {
+		return err
+	}
+
+	// Run symlink fixlet after each Zypper call
+	return sysmgr_fixlets.NewReSymlink(pm.sysroot).Relink()
 }
 
 // Name of the package manager

--- a/sysmgr.go
+++ b/sysmgr.go
@@ -53,6 +53,11 @@ func NewSysrootManager(appname string) *SysrootManager {
 	return srm
 }
 
+// GetSysrootManager tracking
+func (srm *SysrootManager) GetSysrootManager() *sysmgr_sr.SysrootManager {
+	return srm.mgr
+}
+
 // AppName returns a name of the binary, as it should have multiple ones
 func (srm SysrootManager) AppName() string {
 	return srm.appname


### PR DESCRIPTION
Some packages makes absolute symlinks, which is a bug, but doesn't hurt on  the machine provisioning or in a container. However, this breaks child systemroots for target cross-compilation.