### PR TITLE
Prevent sysroot removal while inside of it

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/thoas/go-funk v0.8.0
 	github.com/urfave/cli/v2 v2.3.0
-	golang.org/x/sys v0.0.0-20210601080250-7ecdf8ef093b
+	golang.org/x/sys v0.0.0-20210603125802-9665404d3644
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	howett.net/plist v0.0.0-20201203080718-1454fab16a06 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210601080250-7ecdf8ef093b h1:qh4f65QIVFjq9eBURLEYWqaEXmOyqdUyiBSgaXWccWk=
 golang.org/x/sys v0.0.0-20210601080250-7ecdf8ef093b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210603125802-9665404d3644 h1:CA1DEQ4NdKphKeL70tvsWNdT5oFh1lOjihRcEDROi0I=
+golang.org/x/sys v0.0.0-20210603125802-9665404d3644/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/sr/mgr.go
+++ b/sr/mgr.go
@@ -78,7 +78,11 @@ func (srm *SysrootManager) DeleteSysRoot(name string, arch string) error {
 		return err
 	}
 
-	sysroot := NewSysRoot(srm.sysroots).SetName(name).SetArch(arch)
+	sysroot, err := NewSysRoot(srm.sysroots).SetName(name).SetArch(arch).Init()
+	if err != nil {
+		return err
+	}
+
 	if err := srm.CheckWithinSysroot(sysroot); err != nil {
 		return err
 	}

--- a/sr/sysroot.go
+++ b/sr/sysroot.go
@@ -38,13 +38,17 @@ func NewSysRoot(syspath string) *SysRoot {
 
 // SetName alias
 func (sr *SysRoot) SetName(name string) *SysRoot {
-	sr.Name = name
+	if sr.Name == "" {
+		sr.Name = name
+	}
 	return sr
 }
 
 // SetArch alias
 func (sr *SysRoot) SetArch(arch string) *SysRoot {
-	sr.Arch = arch
+	if sr.Arch == "" {
+		sr.Arch = arch
+	}
 	return sr
 }
 
@@ -80,8 +84,9 @@ func (sr *SysRoot) Init() (*SysRoot, error) {
 		return nil, fmt.Errorf("Invalid or unknown child system root. Configuration missing at %s", sr.confPath)
 	}
 	conf := nanoconf.NewConfig(sr.confPath)
-	sr.Name = conf.Root().String("name", "")
-	sr.Arch = conf.Root().String("arch", "")
+
+	sr.SetName(conf.Root().String("name", ""))
+	sr.SetArch(conf.Root().String("arch", ""))
 
 	isDefault := (*conf.Root().Raw())["default"]
 	if isDefault != nil {

--- a/sysmgr.go
+++ b/sysmgr.go
@@ -313,6 +313,7 @@ func (srm SysrootManager) actionDeleteSysroot(ctx *cli.Context) error {
 	if err := srm.mgr.DeleteSysRoot(name, arch); err != nil {
 		return err
 	}
+
 	roots, err := srm.mgr.GetSysRoots()
 	if err != nil {
 		return err


### PR DESCRIPTION
If user is doing something or is still inside the sysroot, `--delete` operation should be prevented.