### PR TITLE
Skip qemu on ther same arch

### DIFF
--- a/arch/bfmt.go
+++ b/arch/bfmt.go
@@ -130,6 +130,15 @@ func (bf BinFormat) Unregister(arch string) error {
 
 // Register architecture. This previously un-registers possible target.
 func (bf BinFormat) Register(arch string) error {
+	uname := NewUname()
+	if err := uname.Init(); err != nil {
+		return err
+	}
+
+	if uname.Machine == arch {
+		return nil
+	}
+
 	if err := bf.Unregister(arch); err != nil {
 		return err
 	}

--- a/arch/uname.go
+++ b/arch/uname.go
@@ -1,0 +1,52 @@
+package sysmgr_arch
+
+import (
+	"fmt"
+	"strings"
+	"syscall"
+)
+
+// Uname object
+type Uname struct {
+	Nodename   string
+	Release    string
+	Sysname    string
+	Version    string
+	Machine    string
+	Domainname string
+}
+
+// NewUname instance
+func NewUname() *Uname {
+	return new(Uname)
+}
+
+// a2s converts an array of int to a string for syscalls
+func (un *Uname) a2s(data [65]int8) string {
+	var buf [65]byte
+	for i, b := range data {
+		buf[i] = byte(b)
+	}
+	str := string(buf[:])
+	if i := strings.Index(str, "\x00"); i != -1 {
+		str = str[:i]
+	}
+	return str
+}
+
+// Init Uname
+func (un *Uname) Init() error {
+	var uname syscall.Utsname
+	if err := syscall.Uname(&uname); err != nil {
+		return fmt.Errorf("Error init uname: %v", err)
+	}
+
+	un.Nodename = un.a2s(uname.Nodename)
+	un.Release = un.a2s(uname.Release)
+	un.Sysname = un.a2s(uname.Sysname)
+	un.Version = un.a2s(uname.Version)
+	un.Machine = un.a2s(uname.Machine)
+	un.Domainname = un.a2s(uname.Domainname)
+
+	return nil
+}


### PR DESCRIPTION
If a sysroot is created for the same architecture, no QEMU needed for binfmt registration.